### PR TITLE
feat(public api): Update public API

### DIFF
--- a/packages/cli/src/PublicApi/types.d.ts
+++ b/packages/cli/src/PublicApi/types.d.ts
@@ -46,7 +46,7 @@ export declare namespace ExecutionRequest {
 		{},
 		{},
 		{
-			status?: ExecutionStatus;
+			status?: ExecutionStatus | ExecutionStatus[];
 			limit?: number;
 			cursor?: string;
 			offset?: number;

--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -8,7 +8,6 @@ import {
 	deleteExecution,
 	getExecutionsCount,
 } from './executions.service';
-import { ActiveExecutions } from '@/ActiveExecutions';
 import { authorize, validCursor } from '../../shared/middlewares/global.middleware';
 import type { ExecutionRequest } from '../../../types';
 import { getSharedWorkflowIds } from '../workflows/workflows.service';
@@ -95,18 +94,12 @@ export = {
 				return res.status(200).json({ data: [], nextCursor: null });
 			}
 
-			// get running workflows so we exclude them from the result
-			const runningExecutionsIds = Container.get(ActiveExecutions)
-				.getActiveExecutions()
-				.map(({ id }) => id);
-
 			const filters = {
 				status,
 				limit,
 				lastId,
 				includeData,
 				workflowIds: workflowId ? [workflowId] : sharedWorkflowsIds,
-				excludedExecutionsIds: runningExecutionsIds,
 			};
 
 			const executions = await getExecutions(filters);

--- a/packages/cli/src/PublicApi/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/spec/paths/executions.yml
@@ -12,8 +12,14 @@ get:
       description: Status to filter the executions by.
       required: false
       schema:
-        type: string
-        enum: ['error', 'success', 'waiting']
+        oneOf:
+          - type: string
+            enum: ['canceled', 'crashed', 'error', 'failed', 'new', 'running', 'success', 'unknown', 'waiting']
+          - type: array
+            minItems: 1
+            items:
+              type: string
+              enum: ['canceled', 'crashed', 'error', 'failed', 'new', 'running', 'success', 'unknown', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.


### PR DESCRIPTION
Modify API access to give more access to executions
`/executions` now accepts all status filters:
"canceled" | "crashed" | "error" | "failed" | "new" | "running" | "success" | "unknown" | "waiting"

`/executions` now allows for either strings for status or lists
`/executions?status=running,error`
`/executions?status=running`